### PR TITLE
Validate the gitlab token

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,10 @@ function create(options) {
 
     if (req.url.split('?').shift() !== currentOptions.path)
       return callback()
+
+    var token = req.headers['x-gitlab-token']
+    if(!token || token !== currentOptions.secret)
+      return hasError('No X-Gitlab-Token found on request or the token did not match')
     
     var event = req.headers['x-gitlab-event']
     var events = currentOptions.events


### PR DESCRIPTION
The gitlab token provided with each request isn't checked. This pull request checks the token and fails if the token missmatches or isn't provided.